### PR TITLE
cubexx: Implemented set-difference, unit tests for corner_set_t

### DIFF
--- a/include/cubexx/cubexx.hpp
+++ b/include/cubexx/cubexx.hpp
@@ -456,6 +456,16 @@ struct set_base_t
   derived_t operator|(const derived_t& set) const;
   derived_t operator|(const element_t& element) const;
   
+  template<typename Sequence>
+  derived_t& operator-=(const Sequence& sequence);
+  derived_t& operator-=(const derived_t& set);
+  derived_t& operator-=(const element_t& element);
+  
+  template<typename Sequence>
+  derived_t operator-(const Sequence& sequence) const;
+  derived_t operator-(const derived_t& set) const;
+  derived_t operator-(const element_t& element) const;
+  
   bool contains(const element_t& element) const;
   bool contains(const std::size_t& idx) const;
   

--- a/include/cubexx/detail/cubexx.inl.hpp
+++ b/include/cubexx/detail/cubexx.inl.hpp
@@ -1313,7 +1313,7 @@ set_base_t<derived_t, element_t, N>::
 set_base_t(const Sequence& sequence)
   : mbits(0)
 {
-  *this |= sequence;
+  self() |= sequence;
 }
 
 template<typename derived_t, typename element_t, std::size_t N>
@@ -1360,7 +1360,7 @@ derived_t
 set_base_t<derived_t, element_t, N>::
 operator|(const derived_t& set) const
 {
-  return derived_t(*this) |= set;
+  return derived_t(self()) |= set;
 }
 
 
@@ -1370,7 +1370,7 @@ derived_t
 set_base_t<derived_t, element_t, N>::
 operator|(const element_t& element) const
 {
-  return derived_t(*this) | element;
+  return derived_t(self()) | element;
 }
 
 template<typename derived_t, typename element_t, std::size_t N>
@@ -1380,7 +1380,7 @@ derived_t
 set_base_t<derived_t, element_t, N>::
 operator|(const Sequence& sequence) const
 {
-  return derived_t(*this) | sequence;
+  return derived_t(self()) | sequence;
 }
 
 template<typename derived_t, typename element_t, std::size_t N>
@@ -1417,11 +1417,88 @@ operator|=(const Sequence& sequence)
   
   for(const element_t& element : sequence)
   {
-    *this |= element;
+    self() |= element;
   }
   
   return self();
 }
+
+
+
+template<typename derived_t, typename element_t, std::size_t N>
+CORNER_CASES_CUBEXX_INLINE
+derived_t&
+set_base_t<derived_t, element_t, N>::
+operator-=(const derived_t& set)
+{
+  mbits &= ~set.mbits;
+  
+  return self();
+}
+
+template<typename derived_t, typename element_t, std::size_t N>
+CORNER_CASES_CUBEXX_INLINE
+derived_t&
+set_base_t<derived_t, element_t, N>::
+operator-=(const element_t& element)
+{
+  assert(element.index() < N);
+  mbits.set(element.index(), false);
+  return self();
+}
+
+
+
+template<typename derived_t, typename element_t, std::size_t N>
+template<typename Sequence>
+CORNER_CASES_CUBEXX_INLINE
+derived_t&
+set_base_t<derived_t, element_t, N>::
+operator-=(const Sequence& sequence)
+{
+  
+  for(const element_t& element : sequence)
+  {
+    self() -= element;
+  }
+  
+  return self();
+}
+
+
+
+
+
+template<typename derived_t, typename element_t, std::size_t N>
+CORNER_CASES_CUBEXX_INLINE
+derived_t
+set_base_t<derived_t, element_t, N>::
+operator-(const derived_t& set) const
+{
+  return derived_t(self()) -= set;
+}
+
+
+template<typename derived_t, typename element_t, std::size_t N>
+CORNER_CASES_CUBEXX_INLINE
+derived_t
+set_base_t<derived_t, element_t, N>::
+operator-(const element_t& element) const
+{
+  return derived_t(self()) -= element;
+}
+
+template<typename derived_t, typename element_t, std::size_t N>
+template<typename Sequence>
+CORNER_CASES_CUBEXX_INLINE
+derived_t
+set_base_t<derived_t, element_t, N>::
+operator-(const Sequence& sequence) const
+{
+  return derived_t(self()) -= sequence;
+}
+
+
 
 
 template<typename derived_t, typename element_t, std::size_t N>

--- a/src/unittests/cubexx-corner.cpp
+++ b/src/unittests/cubexx-corner.cpp
@@ -636,7 +636,7 @@ TEST_F(CUBEXXCornerTest,corner_set)
         }
     }
     
-    ///check corner_set_t::operator|(corner_set_t) and corner_set_t::operator!=(corner_set_t)
+    ///check corner_set_t::operator|(corner_set_t) and corner_set_t::operator|=(corner_set_t)
     for (uint32_t combo0 = 0; combo0 < 256; ++combo0)
     {
         const auto corner_set0 = all_corner_sets[combo0];
@@ -674,9 +674,140 @@ TEST_F(CUBEXXCornerTest,corner_set)
                 ASSERT_EQ(corner_set, bitmask_to_corner_set(combo0 | combo1));
             }
         }
+        ASSERT_EQ(corner_set0, bitmask_to_corner_set(combo0));
     }
     
     
+    
+    
+    ///check ::operator<<(corner_set_t - corner_set_t)
+    for (uint32_t combo0 = 0; combo0 < 256; ++combo0)
+    {
+        const auto corner_set0 = all_corner_sets[combo0];
+        for (uint32_t combo1 = 0; combo1 < 256; ++combo1)
+        {
+            const auto corner_set1 = all_corner_sets[combo1];
+            
+            std::string result0 = tostr(corner_set0 - corner_set1);
+            
+            const auto corner_set2 = corner_set0 - corner_set1;
+            std::string result1 = tostr(corner_set2);
+            
+            ASSERT_EQ(result0,result1);
+        }
+    }
+    
+    ///check corner_set_t::operator-(corner_t) and corner_set_t::operator-=(corner_t)
+    for (uint32_t base_combo = 0; base_combo < 256; ++base_combo)
+    {
+        
+        for (auto corner : cubexx::corner_t::all())
+        {
+            const auto base_corner_set = all_corner_sets[base_combo];
+            
+            auto index = corner.index();
+            
+            uint32_t expected_result_combo = base_combo & (~(1 << index));
+            
+            
+            ///test operator-
+            {
+                
+                ASSERT_TRUE(bitmask_equal_corner_set( base_corner_set - corner, expected_result_combo))
+                    <<   "base_corner_set:                " << base_corner_set.bits()
+                    << "\n corner:                        " << corner
+                    << "\n corner.index():                " << index
+                    << "\n corner.index():                " << std::bitset<8>(index)
+                    << "\n base_corner_set - corner:      " << (base_corner_set - corner).bits()
+                    << "\n base_combo:                    " << std::bitset<8>(base_combo)
+                    << "\n expected_result_combo:  " << std::bitset<8>(expected_result_combo);
+                ASSERT_TRUE(bitmask_equal_corner_set( base_corner_set - corner, expected_result_combo))
+                    <<   "base_corner_set:                " << base_corner_set.bits()
+                    << "\n corner:                        " << corner
+                    << "\n corner.index():                " << index
+                    << "\n corner.index():                " << std::bitset<8>(index)
+                    << "\n base_corner_set - corner:      " << (base_corner_set - corner).bits()
+                    << "\n base_combo:                    " << std::bitset<8>(base_combo)
+                    << "\n expected_result_combo:  " << std::bitset<8>(expected_result_combo);
+                ASSERT_EQ(base_corner_set - corner, bitmask_to_corner_set(expected_result_combo))
+                    <<   "base_corner_set:                " << base_corner_set.bits()
+                    << "\n corner:                        " << corner
+                    << "\n corner.index():                " << index
+                    << "\n corner.index():                " << std::bitset<8>(index)
+                    << "\n base_corner_set - corner:      " << (base_corner_set - corner).bits()
+                    << "\n base_combo:                    " << std::bitset<8>(base_combo)
+                    << "\n expected_result_combo:  " << std::bitset<8>(expected_result_combo);
+            }
+            
+            
+            ///test operator-=
+            {
+                auto corner_set = base_corner_set;
+                corner_set -= corner;
+                
+                ASSERT_TRUE(bitmask_equal_corner_set(corner_set, expected_result_combo));
+                ASSERT_EQ(corner_set, bitmask_to_corner_set(expected_result_combo));
+            }
+            
+            
+            ASSERT_EQ(base_corner_set, all_corner_sets[base_combo]);
+            ASSERT_EQ(base_corner_set, bitmask_to_corner_set(base_combo));
+        }
+    }
+    
+    ///check corner_set_t::operator-(corner_set_t) and corner_set_t::operator-=(corner_set_t)
+    for (uint32_t combo0 = 0; combo0 < 256; ++combo0)
+    {
+        const auto left_corner_set = all_corner_sets[combo0];
+        for (uint32_t combo1 = 0; combo1 < 256; ++combo1)
+        {
+            const auto right_corner_set = all_corner_sets[combo1];
+            uint32_t expected_result_combo = combo0 & (~combo1);
+            
+            
+            
+            ASSERT_TRUE( expected_result_combo < 256 );
+            
+            ///this has no bits of combo1
+            ASSERT_EQ(expected_result_combo & combo1, uint32_t(0));
+            
+            ///expected_result_combo => combo0
+            ASSERT_EQ(uint32_t((~expected_result_combo) | combo0), uint32_t(-1));
+            
+            
+            
+            
+            ///test operator-
+            {
+                
+                ASSERT_TRUE(bitmask_equal_corner_set( left_corner_set - right_corner_set, expected_result_combo))
+                    <<   "left_corner_set:                " << left_corner_set.bits()
+                    << "\n right_corner_set:               " << right_corner_set.bits()
+                    << "\n left_corner_set - right_corner_set: " << (left_corner_set - right_corner_set).bits()
+                    << "\n combo0:          " << combo0
+                    << "\n combo1:          " << combo1
+                    << "\n expected_result_combo: " << (expected_result_combo);
+                ASSERT_TRUE(bitmask_equal_corner_set( left_corner_set - right_corner_set, expected_result_combo))
+                    <<   "left_corner_set:                " << left_corner_set.bits()
+                    << "\n right_corner_set:               " << right_corner_set.bits()
+                    << "\n left_corner_set - right_corner_set: " << (left_corner_set - right_corner_set);
+                ASSERT_EQ(left_corner_set - right_corner_set, bitmask_to_corner_set(expected_result_combo))
+                    <<   "left_corner_set:                " << left_corner_set.bits()
+                    << "\n right_corner_set:               " << right_corner_set.bits()
+                    << "\n left_corner_set - right_corner_set: " << (left_corner_set - right_corner_set);
+            }
+            ///test operator-=
+            {
+                auto result_corner_set = left_corner_set;
+                result_corner_set -= right_corner_set;
+                
+                ASSERT_TRUE(bitmask_equal_corner_set(result_corner_set, expected_result_combo));
+                ASSERT_EQ(result_corner_set, bitmask_to_corner_set(expected_result_combo));
+            }
+            ASSERT_EQ(left_corner_set, bitmask_to_corner_set(combo0));
+            ASSERT_EQ(right_corner_set, bitmask_to_corner_set(combo1));
+        }
+    }
     ///check ::operator<<
     /*
     for (uint32_t combo0 = 0; combo0 < 256; ++combo0)
@@ -712,7 +843,6 @@ TEST_F(CUBEXXCornerTest,corner_set)
                                 , fmt::arg("space", space_re)
                                 , fmt::arg("corner", corner_re)
                                 );
-        
         
         std::string final_re_str = corner_list_re;
         


### PR DESCRIPTION
- Replaced all uses of *this with self(), in set_base_t (CRTP)
